### PR TITLE
Collection Macro update

### DIFF
--- a/src/PresenterServiceProvider.php
+++ b/src/PresenterServiceProvider.php
@@ -6,6 +6,7 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Collection;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Facades\Response;
+use Illuminate\Pagination\AbstractPaginator;
 use Illuminate\Contracts\Container\Container;
 
 class PresenterServiceProvider extends ServiceProvider
@@ -70,10 +71,17 @@ class PresenterServiceProvider extends ServiceProvider
     protected function loadCollectionMacros(Container $app)
     {
         Collection::macro('present', function ($data) {
+            if ($data instanceof AbstractPaginator) {
+                $data->setCollection(
+                    collect(app('davidianbonner.presenter')->transform($data->items()))
+                );
+            }
+
             return Collection::make($data)->mapWithKeys(function ($value, $key) {
                 return [$key => app('davidianbonner.presenter')->transform($value)];
             });
         });
+
     }
 
     /**

--- a/src/PresenterServiceProvider.php
+++ b/src/PresenterServiceProvider.php
@@ -81,7 +81,6 @@ class PresenterServiceProvider extends ServiceProvider
                 return [$key => app('davidianbonner.presenter')->transform($value)];
             });
         });
-
     }
 
     /**


### PR DESCRIPTION
The Collection::present macro will now replace the collection within an
AbstractPaginator instance with a presented Collection.

Previously, this was being skipped and cast to an array, bypassing the
presenter due to the Collection::make call.